### PR TITLE
Add movement counter example for Waveshare ESP32-S3

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,35 @@
-# lylygo
+# ESP32-S3 Movement Counter
+
+This repository contains a simple MicroPython application for the Waveshare ESP32-S3 Touch LCD 1.28" board. The program reads motion data from the onboard **QMI8658** accelerometer/gyroscope and shows a counter on the round 1.28" LCD (GC9A01A).
+
+The application is designed for fitness tracking. Wear the device on your chest or arm during exercises. Each detected movement increments the displayed count.
+
+## Installation
+
+1. Flash the Waveshare MicroPython firmware provided on the [product wiki](https://www.waveshare.com/wiki/ESP32-S3-Touch-LCD-1.28) using `esptool.py`.
+2. Install `mpremote` (comes with recent MicroPython packages) on your computer:
+   ```bash
+   pip install mpremote
+   ```
+3. Clone this repository and copy `main.py` and `qmi8658.py` to the board:
+   ```bash
+   mpremote connect /dev/ttyACM0 fs cp main.py :/main.py
+   mpremote connect /dev/ttyACM0 fs cp qmi8658.py :/qmi8658.py
+   ```
+   Replace the serial port with the one shown on your system.
+
+## Usage
+
+1. Reset or power the board.
+2. The display shows the current movement count starting from zero.
+3. Perform your workout. Each time the algorithm detects a complete motion, the counter increases.
+
+## Configuration
+
+The detection threshold values in `main.py` may require adjustment depending on the exercise and how the board is worn. Edit `THRESH_HIGH` and `THRESH_LOW` in the script for best results.
+
+## Files
+
+- `main.py` – application entry point; sets up the display and IMU and updates the counter.
+- `qmi8658.py` – minimal driver for the QMI8658 accelerometer/gyroscope.
+

--- a/main.py
+++ b/main.py
@@ -1,0 +1,44 @@
+from machine import Pin, SPI, I2C
+import time
+import gc9a01
+from qmi8658 import QMI8658
+
+# SPI configuration for the GC9A01A display
+spi = SPI(2, baudrate=80_000_000, sck=Pin(10), mosi=Pin(11), miso=Pin(12))
+
+lcd = gc9a01.GC9A01(
+    spi=spi,
+    cs=Pin(9),
+    dc=Pin(8),
+    rst=Pin(15),
+    backlight=Pin(2),
+    width=240,
+    height=240,
+    rotation=0,
+)
+
+lcd.init()
+
+# I2C for QMI8658 and touch controller
+i2c = I2C(0, scl=Pin(7), sda=Pin(6))
+imu = QMI8658(i2c)
+
+count = 0
+state = 0
+THRESH_HIGH = 1.5
+THRESH_LOW = 1.0
+
+lcd.fill(gc9a01.BLACK)
+lcd.text("Count: 0", 60, 120, gc9a01.WHITE)
+
+while True:
+    ax, ay, az, gx, gy, gz = imu.read()
+    magnitude = (ax * ax + ay * ay + az * az) ** 0.5
+    if state == 0 and magnitude > THRESH_HIGH:
+        state = 1
+    elif state == 1 and magnitude < THRESH_LOW:
+        state = 0
+        count += 1
+        lcd.fill(gc9a01.BLACK)
+        lcd.text("Count: {}".format(count), 60, 120, gc9a01.WHITE)
+    time.sleep_ms(50)

--- a/qmi8658.py
+++ b/qmi8658.py
@@ -1,0 +1,36 @@
+from machine import I2C
+import struct
+import time
+
+class QMI8658:
+    """Minimal driver for the QMI8658 6-axis IMU."""
+
+    def __init__(self, i2c: I2C, addr: int = 0x6B) -> None:
+        self.i2c = i2c
+        self.addr = addr
+        self.init()
+
+    def init(self) -> None:
+        """Basic initialization of the sensor."""
+        try:
+            # Reset and wake up
+            self.i2c.writeto_mem(self.addr, 0x02, b"\x80")
+            time.sleep_ms(10)
+            self.i2c.writeto_mem(self.addr, 0x02, b"\x00")
+            # Configure ranges (±8g, ±2000 dps) and start
+            self.i2c.writeto_mem(self.addr, 0x1F, b"\x03")
+            self.i2c.writeto_mem(self.addr, 0x20, b"\x07")
+        except OSError:
+            pass
+
+    def read(self):
+        """Read and return acceleration (g) and gyro (dps) values."""
+        data = self.i2c.readfrom_mem(self.addr, 0x35, 12)
+        ax, ay, az, gx, gy, gz = struct.unpack("<hhhhhh", data)
+        ax /= 4096.0
+        ay /= 4096.0
+        az /= 4096.0
+        gx /= 32.8
+        gy /= 32.8
+        gz /= 32.8
+        return ax, ay, az, gx, gy, gz


### PR DESCRIPTION
## Summary
- implement simple MicroPython example using QMI8658 IMU and GC9A01A LCD
- include minimal IMU driver
- document installation and usage steps

## Testing
- `python3 -m py_compile main.py qmi8658.py`


------
https://chatgpt.com/codex/tasks/task_b_6847e7745164832eab6dc0d1e531360d